### PR TITLE
Reflect host DNS resolver changes to the container

### DIFF
--- a/secbox
+++ b/secbox
@@ -86,6 +86,7 @@ print_logo() {
 declare -r tmp_dir=${XDG_RUNTIME_DIR:-/tmp}
 declare -r container="secbox"
 declare -r script_name=$(basename "${BASH_SOURCE[0]}")
+declare -r resolv_conf="${tmp_dir}/${container}-resolv.conf"
 declare -r registry="registry.suse.de"
 declare -r registry_api="https://${registry}/v2/"
 declare -r image_name="non_public/maintenance/security/container/containers/secbox"
@@ -459,6 +460,8 @@ create_container() {
                             --userns=keep-id \
                             -u $(id -u) \
                             --network host \
+                            --dns=none \
+                            -v ${resolv_conf}:/etc/resolv.conf:ro \
                             -v ${tmp_dir}:${tmp_dir} \
                             -v ${HOME}:${HOME} \
                             -w ${HOME} \
@@ -613,6 +616,20 @@ container_is_not_running() {
     # Toggled return value
 }
 
+sync_name_resolvers() {
+    # I want the container resolv.conf reflect the one in the host. This would allow containerized binaries
+    # to resolve network resources in case the host resolvers are changed.
+    # An easiest solution would be to bind mount /etc/resolv.conf, but unfortunately NetworkManager replace
+    # this file instead of updating it in place, which in turn breaks the bind mount.
+    # This function is intended to maintain a custom file with the same content of the host's resolv.conf
+    #
+    # For more info: https://github.com/containers/podman/issues/11042
+    #                https://github.com/containers/podman/issues/10026
+    #                https://github.com/StayPirate/secbox/issues/5
+
+    cat /etc/resolv.conf > ${resolv_conf}
+}
+
 secbox_exec() {
     # Podman misbehaves when pipes are involved, as reported here
     # https://github.com/containers/podman/issues/9718#issuecomment-799925847
@@ -666,6 +683,8 @@ secbox_destroy(){
         msg "${red}[!]${no_format} ${container} container cannot be deleted"
         return 1
     fi
+
+    [ -f ${resolv_conf} ] && rm -f ${resolv_conf}
 }
 
 secbox_root() {
@@ -719,6 +738,8 @@ main() {
         esac
         shift
     done
+
+    sync_name_resolvers
 
     if suse_internal_network; then
         update_available && update_image


### PR DESCRIPTION
Fix #5.

If you run secbox for the first time while you are not yet connected to
the company VPN, you won't be able to reach out to the internal network
resources even after you connect your host system to the VPN. This
commit makes the container works with all the network resources
independently from when the container was created at the first instance.

/etc/resolv.conf is copied over the container from the host system by
podman during the container creation. If your host /etc/resolv.conf
changes after the container creation, let's say you connect to your
company's VPN, the newly added nameservers (provided by the company via
DHCP) won't be reflected within the container /etc/resolv.conf.
Bind mounting /etc/resolv.conf would be an option, but unfortunately
NetworkManager replace the host /etc/resolv.conf instead of updating its
content in place. This of course breaks the bind mount.
The solution I adopted here is to use a copy of /etc/resolv.conf
maintained by secbox, which takes care of syncing it at every run with
the host one, without delete or rename the file.

For more info check [0][1][2].

[0] https://github.com/containers/podman/issues/11042
[1] https://github.com/containers/podman/issues/10026
[2] https://github.com/StayPirate/secbox/issues/5