### PR TITLE
fix(sshfs): Replace wotan with dist.suse.de after its decommission

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,23 +52,23 @@ TODO: description
       Can be triggered through the option `--nfs`, since `mount` requires high privileges, then you'll be prompted to input your user's password. A list of mounted exports is maintained with the [`nfs_shares` array](https://github.com/StayPirate/secbox/blob/master/secbox#L97-L107). I suggest using this option just in case the one described below cannot.
 
    2. SSHFS *(prefered)*  
-      A **better approach** is the `--sshfs` option. Secbox uses sshfs (no need to install sshfs in your host) to mount `wotan.suse.de:/mounts` and `wotan.suse.de:/suse` in the expected paths inside the container. In order to make this option working you need to configure your host to be able to access `wotan.suse.de` just by running
+      A **better approach** is the `--sshfs` option. Secbox uses sshfs (no need to install sshfs in your host) to mount `dist.suse.de:/mounts` and `dist.suse.de:/suse` in the expected paths inside the container. In order to make this option working you need to configure your host to be able to access `dist.suse.de` just by running
 
-          host> ssh wotan
+          host> ssh dist
 
       That can easily be accomplished throught a properly configured `~/.ssh/config`. You could use the following stanza template:
 
-          Host wotan
-              HostName wotan.suse.de
+          Host dist
+              HostName dist.suse.de
               User <YOUR_USERNAME>
               PreferredAuthentications publickey
               IdentityFile /path/to/your/key
 
       In case your ssh keys are manged by the ssh-agent, then you can avoid the last line *(IdentityFile)*, because secbox will automatically talk to the ssh-agent.
 
-      To check if your ssh setup is fine, try to access wotan via `ssh wotan`:
+      To check if your ssh setup is fine, try to access dist via `ssh dist`:
 
-            host> ssh wotan
+            host> ssh dist
             Last login: Fri Jul 30 06:32:42 2021 from 2620:113:80c0:8340::11f1
             This machine is used as:
             * ...
@@ -83,7 +83,7 @@ TODO: description
 
             Have a lot of fun...
 
-            <YOUR_USERNAME>@wotan:~>
+            <YOUR_USERNAME>@dist:~>
 
 ## Try it
 

--- a/secbox
+++ b/secbox
@@ -56,11 +56,11 @@ For more information: https://github.com/StayPirate/secbox
 
 Available options:
 
---sshfs             Makes wotan:/mounts and wotan:/suse available to the container.
-                    In order to works you should be able to access wotan.suse.de via ssh
-                    from your host system by simply run 'ssh wotan', without interaction
+--sshfs             Makes dist:/mounts and dist:/suse available to the container.
+                    In order to works you should be able to access dist.suse.de via ssh
+                    from your host system by simply run 'ssh dist', without interaction
                     You can find an example stanza in the README.md of this project.
-                    ${script_name} support ssh-agent out-of-the-box if it's configured
+                    ${script_name} supports ssh-agent out-of-the-box if it's configured
                     in the host system.
 --nfs               Alternative to --sshfs, it makes some of the NFS exports available
                     to the container. --sshfs should be prefered.
@@ -157,7 +157,7 @@ cleanup() {
             # Check if a parallel secbox instance is using sshfs, if yes do not umount
             if [[ $(secbox_instances_using_sshfs) -le 3 ]]; then
                 sshfs_umount &&
-                    msg_to_secbox_sessions "==== Another ${script_name} instance has umounted wotan:/mounts in /mounts ===="
+                    msg_to_secbox_sessions "==== Another ${script_name} instance has umounted dist:/mounts in /mounts ===="
             fi
         fi
     fi
@@ -288,7 +288,7 @@ enable_container_service() {
 suse_internal_network() {
     # Check if VPN connection is available, fail if any of the following end-point is not reachable
     local -ar _know_internal_addresses=(
-        # Check reachability of wotan's ssh service, since it likely has best uptime
+        # Check reachability of login's ssh service, since it likely has best uptime
         "10.144.39.65/22"
         # dns lookup can introduce a very long delay when the dns server is not
         # reachable, so I test domain name resolution only if the above worked
@@ -405,9 +405,9 @@ sshfs_mount() {
     }
 
     podman container exec -d $container mkdir -p /mounts > /dev/null 2>&1
-    podman >/dev/null 2>&1 container exec --env-file="$host_env" -d $container sshfs -o ro,StrictHostKeyChecking=no,compression=yes wotan:/mounts /mounts
+    podman >/dev/null 2>&1 container exec --env-file="$host_env" -d $container sshfs -o ro,StrictHostKeyChecking=no,compression=yes dist:/mounts /mounts
     podman container exec -d $container mkdir -p /suse > /dev/null 2>&1
-    podman >/dev/null 2>&1 container exec --env-file="$host_env" -d $container sshfs -o ro,StrictHostKeyChecking=no,compression=yes wotan:/suse   /suse
+    podman >/dev/null 2>&1 container exec --env-file="$host_env" -d $container sshfs -o ro,StrictHostKeyChecking=no,compression=yes dist:/suse   /suse
 }
 
 sshfs_umount() {
@@ -462,18 +462,18 @@ mount_remote_volumes() {
     fi
 
     if [[ -n $sshfs_flag ]] && ! sshfs_is_mounted; then
-        if ! ssh -qo "BatchMode=yes" wotan exit; then
-            msg "${orange}[*]${no_format} ${container} cannot access wotan via 'ssh wotan'.
-    Please ensure you have properly configured wotan in your ~/.ssh/config. A valid stanza should be like:
-    Host wotan
-        HostName wotan.suse.de
+        if ! ssh -qo "BatchMode=yes" dist exit; then
+            msg "${orange}[*]${no_format} ${container} cannot access dist via 'ssh dist'.
+    Please ensure you have properly configured dist in your ~/.ssh/config. A valid stanza should be like:
+    Host dist
+        HostName dist.suse.de
         User <YOUR_USERNAME>
         PreferredAuthentications publickey
         IdentityFile /path/to/your/key
     you could avoid IdentityFile in case your key is loaded in the ssh-agent, in this case ${script_name} will use it"
         else
             sshfs_mount &&
-                msg_to_secbox_sessions "==== Another ${script_name} instance has mounted wotan:/mounts in /mounts ===="
+                msg_to_secbox_sessions "==== Another ${script_name} instance has mounted dist:/mounts in /mounts ===="
         fi
     fi
 }


### PR DESCRIPTION
Wotan was used in secbox to automatically provides network shares required by some of our internal tools. It's been decommissioned by the infra team, so I'm replacing it with dist.suse.de which in turn provides the same network shares.

This is a breaking change because it requires users to configure again their ~/.ssh/config files. See the README.md for instructions.